### PR TITLE
Allow custom aspect ratios

### DIFF
--- a/nano_banano.py
+++ b/nano_banano.py
@@ -229,7 +229,7 @@ class ComfyUI_NanoBanana:
             
         return final_prompt
 
-    def call_nano_banana_api(self, prompt, encoded_images, temperature, batch_count, enable_safety):
+    def call_nano_banana_api(self, prompt, encoded_images, temperature, batch_count, enable_safety, aspect_ratio=None):
         """Make API call to the Gemini 2.5 Flash Image model"""
         
         try:
@@ -251,11 +251,16 @@ class ComfyUI_NanoBanana:
                     if cat.name != "HARM_CATEGORY_UNSPECIFIED"
                 ]
 
-            generation_config = types.GenerateContentConfig(
-                temperature=temperature,
-                response_modalities=['TEXT', 'IMAGE'],
-                safety_settings=safety_settings,
-            )
+            config_kwargs = {
+                "temperature": temperature,
+                "response_modalities": ["TEXT", "IMAGE"],
+                "safety_settings": safety_settings,
+            }
+
+            if aspect_ratio:
+                config_kwargs["aspect_ratio"] = aspect_ratio
+
+            generation_config = types.GenerateContentConfig(**config_kwargs)
 
             # Build prompt parts using official SDK helpers
             parts = [types.Part.from_text(text=prompt)]
@@ -395,8 +400,9 @@ class ComfyUI_NanoBanana:
             operation_log += f"Prompt: {final_prompt[:150]}...\n\n"
             
             # Make API call
+            api_aspect_ratio = None if operation == "edit" else aspect_ratio
             generated_images, api_log = self.call_nano_banana_api(
-                final_prompt, encoded_images, temperature, batch_count, enable_safety
+                final_prompt, encoded_images, temperature, batch_count, enable_safety, api_aspect_ratio
             )
             
             operation_log += api_log


### PR DESCRIPTION
## Summary
- pass aspect_ratio through GenerateContentConfig so Gemini can create non-square images
- forward aspect_ratio from node unless editing existing images

## Testing
- `python -m py_compile nano_banano.py`


------
https://chatgpt.com/codex/tasks/task_e_68b163fb353c832ca6e74bfb7750777c